### PR TITLE
[DEV] Replace m2r with m2r2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bolt-ta
 conttest
 coverage
-m2r
+m2r2
 nose
 sphinx
 sphinx-rtd-theme

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-from m2r import parse_from_file
+from m2r2 import parse_from_file
 from os import path
 from pythern import about
 


### PR DESCRIPTION
Replaces the deprecated package `m2r` with the new `m2r2` to prepare for creating documentation.